### PR TITLE
Remove `Ed25519Signature2018` tags from implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # vc-test-suite-implementations Changelog
 
+## 2.1.0 - 2023-12-15
+
+### Removed
+- Remove tags unsupported `Ed25519Signature2018` tag from implementations.
+
 ## 2.0.0 - 2023-12-14
 
 ### Changed

--- a/implementations/Mavennet.json
+++ b/implementations/Mavennet.json
@@ -13,11 +13,11 @@
     "options": {
       "type": "Ed25519Signature2018"
     },
-    "tags": ["vc-api", "Ed25519Signature2018"]
+    "tags": ["vc-api"]
   }],
   "verifiers": [{
     "id": "",
     "endpoint": "https://api.staging.refiner.neoflow.energy/credentials/verify",
-    "tags": ["vc-api", "Ed25519Signature2018"]
+    "tags": ["vc-api"]
   }]
 }


### PR DESCRIPTION
None of the test suites uses that tag and also `Ed25519Signature2018` is no longer supported.

Question though is do we want to remove the implementations that have the tag `vc-api` with option `Ed25519Signature2018`? I believe they are issuing VCs with `Ed25519Signature2018` proof type.

Mavennet and Danube Tech uses `Ed25519Signature2018` option for their vc-api implementations.