### PR TITLE
Add Procivis One Core implementation

### DIFF
--- a/implementations/ProcivisOneCore.json
+++ b/implementations/ProcivisOneCore.json
@@ -1,0 +1,25 @@
+{
+  "name": "Procivis One Core",
+  "implementation": "Procivis One Core",
+  "issuers": [
+    {
+      "id": "did:key:zDnaebiWvYW4sEFcncp6sLRmGPio1tVaXSDBwnYELtyvwpnYE",
+      "endpoint": "https://canivc.core.dev.procivis-one.com/vc-api/credentials/issue",
+      "tags": [ "vc-api" ]
+    }
+  ],
+  "verifiers": [
+    {
+      "id": "did:key:zDnaebiWvYW4sEFcncp6sLRmGPio1tVaXSDBwnYELtyvwpnYE",
+      "endpoint": "https://canivc.core.dev.procivis-one.com/vc-api/credentials/verify",
+      "tags": [ "vc-api" ]
+    }
+  ],
+  "didResolvers": [
+    {
+      "id": "resolver",
+      "endpoint": "https://canivc.core.dev.procivis-one.com/vc-api/identifiers",
+      "tags": [ "did-key" ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the Procivis One Core implementation. 

If I understand correctly the configurations relevant to the VC-API issuer / verifier tests, as well as the `did:key` interop  should be included in this repository as opposed to the [w3c test suite implementations](https://github.com/w3c/vc-test-suite-implementations). If this is correct I can open a follow-up pull request to the w3c implementations repository and remove the `vc-api` tags included there.

Thank you!